### PR TITLE
Fixed issue with vertical resizing causing a small vertical spacing change

### DIFF
--- a/enaml/widgets/check_box.py
+++ b/enaml/widgets/check_box.py
@@ -27,3 +27,6 @@ class CheckBox(ToggleControl):
     #: Overridden parent class trait
     abstract_obj = Instance(AbstractTkCheckBox)
 
+    hug_width = "strong"
+    hug_height = "strong"
+

--- a/enaml/widgets/component.py
+++ b/enaml/widgets/component.py
@@ -112,13 +112,13 @@ class Component(BaseComponent):
     #: are 'weak', 'medium', 'strong', 'required' and 'ignore'. 
     #: The default is 'strong'. This trait should be overridden on a per-control
     #: basis to specify  a logical default for the given control.
-    hug_width = PolicyEnum('strong')
+    hug_width = PolicyEnum('medium')
 
     #: How strongly a component hugs it's contents' height. Valid strengths
     #: are 'weak', 'medium', 'strong', 'required' and 'ignore'. 
     #: The default is 'strong'. This trait should be overridden on a per-control
     #: basis to specify  a logical default for the given control.
-    hug_height = PolicyEnum('strong')
+    hug_height = PolicyEnum('medium')
 
     #: The combination of (hug_width, hug_height).
     hug = Property(Tuple(PolicyEnum, PolicyEnum), depends_on=['hug_width', 'hug_height'])


### PR DESCRIPTION
This fixes the issue with the slight vertical jump when resizing a group of widgets that are layed out vertically. I've tested all combinations of widgets and this change in weighting seems stable.
