### PR TITLE
Fixed package issue causing Canopy crash due to missing .enaml files in egg.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(name='enaml',
     long_description=open('README.rst').read(),
     requires=['traits', 'PySide', 'ply', 'wx', 'argparse'],
     install_requires=['distribute'],
+    package_data = {
+        'enaml.stdlib': ['*.enaml']
+    },
     packages=find_packages(),
     entry_points = dict(
         console_scripts = [


### PR DESCRIPTION
Fixed Canopy crash due to missing radio_group.enaml file in stdlib (and ......others). Just a package-building issue.
