### PR TITLE
ENH: Add range fields (text fields for numeric values with bounds)

### DIFF
--- a/docs/source/instructional/tut_person.rst
+++ b/docs/source/instructional/tut_person.rst
@@ -64,6 +64,7 @@ from other components.
      Label:
          text = 'Age'
      IntField:
+         low = 0
          value := person.age 
 
 A component declaration block header line begins with the name of the component

--- a/enaml/stdlib/fields.enaml
+++ b/enaml/stdlib/fields.enaml
@@ -2,23 +2,61 @@
 #  Copyright (c) 2011, Enthought, Inc.
 #  All rights reserved.
 #------------------------------------------------------------------------------
-from enaml.converters import IntConverter, FloatConverter, LongConverter, ComplexConverter
+
+from enaml.converters import IntConverter, FloatConverter, LongConverter, \
+                                HexConverter, OctalConverter, ComplexConverter
 
 
 ErrorField(Field):
     bg_color << 'error' if error else 'none'
 
 
-IntField(ErrorField):
-    converter = IntConverter()
+RangeField(ErrorField):
+    # Base class for text fields that allow editing a data type that has
+    # a natural ordering (e.g. int, float).  This class provides the option
+    # of defining lower and upper bounds of the value.
+
+    # The low end of the valid range.  `None` means no minimum.
+    attr low = None
+
+    # The high end of the valid range.  `None` means no maximum.
+    attr high = None
+
+    # A boolean value that determines if the value of `low` is included in
+    # the valid range.
+    attr allow_low = True
+
+    # A boolean value that determines if the value of `high` is included in
+    # the valid range.
+    attr allow_high = True
+
+    # `converter` must be assigned in subclasses.
+    converter = None
 
 
-LongField(ErrorField):
-    converter = LongConverter()
+IntField(RangeField):
+    converter << IntConverter(low=low, high=high,
+                              allow_low=allow_low, allow_high=allow_high)
 
 
-FloatField(ErrorField):
-    converter = FloatConverter()
+LongField(RangeField):
+    converter << LongConverter(low=low, high=high,
+                               allow_low=allow_low, allow_high=allow_high)
+
+
+FloatField(RangeField):
+    converter << FloatConverter(low=low, high=high,
+                                allow_low=allow_low, allow_high=allow_high)
+
+
+HexField(RangeField):
+    converter << HexConverter(low=low, high=high,
+                              allow_low=allow_low, allow_high=allow_high)
+
+
+OctalField(RangeField):
+    converter << OctalConverter(low=low, high=high,
+                                allow_low=allow_low, allow_high=allow_high)
 
 
 ComplexField(ErrorField):
@@ -27,4 +65,3 @@ ComplexField(ErrorField):
 
 PasswordField(Field):
     password_mode = 'password'
-

--- a/enaml/tests/converters/converter_test_case.py
+++ b/enaml/tests/converters/converter_test_case.py
@@ -3,7 +3,7 @@
 #  All rights reserved.
 #------------------------------------------------------------------------------
 import unittest
-
+from enaml.converters import RangeConverter
 
 class ConverterTestCase(unittest.TestCase):
     """ A base class for testing `enaml.converters.Converter` objects.
@@ -22,3 +22,10 @@ class ConverterTestCase(unittest.TestCase):
         self.assertEqual(widget_converted, widget_value)
 
         # XXX Should we check the types?
+
+    def reset_converter(self):
+        if isinstance(self.converter, RangeConverter):
+            self.converter.low = None
+            self.converter.high = None
+            self.converter.allow_low = True
+            self.converter.allow_high = True

--- a/enaml/tests/converters/test_converters.py
+++ b/enaml/tests/converters/test_converters.py
@@ -124,6 +124,58 @@ class TestIntConverter(ConverterTestCase):
         """
         self.assertRaises(ValueError, self.converter.from_component, '')
 
+    def test_ranges(self):
+        self.converter.low = 0
+        self.converter.high = 9
+        self.assertEqual(self.converter.from_component('0'), 0)
+        self.assertEqual(self.converter.from_component('9'), 9)
+        self.assertRaises(ValueError, self.converter.from_component, '10')
+        self.assertRaises(ValueError, self.converter.from_component, '-1')
+        self.converter.allow_high = False
+        self.assertRaises(ValueError, self.converter.from_component, '9')
+        self.converter.allow_low = False
+        self.assertRaises(ValueError, self.converter.from_component, '0')
+
+        self.reset_converter()
+
+
+class TestLongConverter(ConverterTestCase):
+    """ Test the long integer converter.
+
+    """
+    def setUp(self):
+        """ Create an IntConverter.
+
+        """
+        self.converter = converters.LongConverter()
+
+    def test_symmetry(self):
+        """ Test that the 'to_component' and 'from_component' methods are
+        symmetric.
+
+        """
+        self.assertConverterSymmetric(self.converter, '42', 42)
+
+    def test_empty_string_conversion_failure(self):
+        """ Test that the empty string cannot be converted.
+
+        """
+        self.assertRaises(ValueError, self.converter.from_component, '')
+
+    def test_ranges(self):
+        self.converter.low = 0L
+        self.converter.high = 4294967296L
+        self.assertEqual(self.converter.from_component('0'), 0L)
+        self.assertEqual(self.converter.from_component('4294967296'), 4294967296L)
+        self.assertRaises(ValueError, self.converter.from_component, 4294967296L+1)
+        self.assertRaises(ValueError, self.converter.from_component, '-1')
+        self.converter.allow_high = False
+        self.assertRaises(ValueError, self.converter.from_component, '4294967296')
+        self.converter.allow_low = False
+        self.assertRaises(ValueError, self.converter.from_component, '0')
+
+        self.reset_converter()
+
 
 class TestHexConverter(ConverterTestCase):
     """ Test the hexadecimal converter.
@@ -148,6 +200,19 @@ class TestHexConverter(ConverterTestCase):
         """
         self.assertRaises(ValueError, self.converter.from_component, '')
 
+    def test_ranges(self):
+        self.converter.low = 0
+        self.converter.high = 255
+        self.assertEqual(self.converter.from_component('0'), 0)
+        self.assertEqual(self.converter.from_component('FF'), 255)
+        self.assertRaises(ValueError, self.converter.from_component, '100')
+        self.converter.allow_high = False
+        self.assertRaises(ValueError, self.converter.from_component, 'FF')
+        self.converter.allow_low = False
+        self.assertRaises(ValueError, self.converter.from_component, '0')
+
+        self.reset_converter()
+
 
 class TestOctalConverter(ConverterTestCase):
     """ Test the octal converter.
@@ -171,6 +236,19 @@ class TestOctalConverter(ConverterTestCase):
 
         """
         self.assertRaises(ValueError, self.converter.from_component, '')
+
+    def test_ranges(self):
+        self.converter.low = 0
+        self.converter.high = 63
+        self.assertEqual(self.converter.from_component('0'), 0)
+        self.assertEqual(self.converter.from_component('77'), 63)
+        self.assertRaises(ValueError, self.converter.from_component, '100')
+        self.converter.allow_high = False
+        self.assertRaises(ValueError, self.converter.from_component, '77')
+        self.converter.allow_low = False
+        self.assertRaises(ValueError, self.converter.from_component, '0')
+
+        self.reset_converter()
 
 
 class TestFloatConverter(ConverterTestCase):
@@ -201,6 +279,19 @@ class TestFloatConverter(ConverterTestCase):
 
         """
         self.assertRaises(ValueError, self.converter.from_component, '')
+
+    def test_ranges(self):
+        self.converter.low = -10.0
+        self.converter.high = 10.0
+        self.assertEqual(self.converter.from_component('0'), 0.0)
+        self.assertEqual(self.converter.from_component('-1.5'), -1.5)
+        self.assertRaises(ValueError, self.converter.from_component, '100')
+        self.converter.allow_high = False
+        self.assertRaises(ValueError, self.converter.from_component, '10')
+        self.converter.allow_low = False
+        self.assertRaises(ValueError, self.converter.from_component, '-10')
+
+        self.reset_converter()
 
 
 class TestDateConverter(ConverterTestCase):

--- a/examples/person/person_view.enaml
+++ b/examples/person/person_view.enaml
@@ -18,7 +18,8 @@ PersonForm(Form):
     Label:
         text = 'Age'
     IntField:
-        value := person.age 
+        low = 0
+        value := person.age
 
 
 defn PersonView(person):

--- a/examples/stdlib/range_demo.py
+++ b/examples/stdlib/range_demo.py
@@ -1,0 +1,53 @@
+#------------------------------------------------------------------------------
+#  Copyright (c) 2011, Enthought, Inc.
+#  All rights reserved.
+#------------------------------------------------------------------------------
+
+from traits.api import HasTraits, Range, Float, Long, on_trait_change
+
+
+class RangeDemo(HasTraits):
+    """Demonstrate numeric text fields with restricted ranges.
+
+    The Range trait attributes are not inspected by enaml.  It is up to the
+    author of the .enaml file to match the UI attributes to the Trait
+    attributes.
+    """
+
+    i = Range(low=0)
+
+    digit = Range(low=0, high=9)
+
+    h = Range(low=0, high=255)
+
+    bigint = Long(1000L)
+
+    z = Range(low=0.0, high=10.0, value=5)
+
+    b_min = Range(high=0.0, value=-1.0)
+
+    b_max = Range(low=0.0, value=1.0)
+
+    b = Range(low='b_min', high='b_max', value=0.0)
+
+
+    def _anytrait_changed(self):
+        """Prints all the trait values whenever a trait changes."""
+        for name in self.editable_traits():
+            print "{name} = {value}  ".format(name=name, value=repr(getattr(self, name))),
+        print
+
+
+def enaml_demo():
+    import enaml
+    with enaml.imports():
+        from range_demo_view import RangeDemoView
+
+    demo = RangeDemo()
+
+    view = RangeDemoView(demo)
+    view.show()
+
+
+if __name__ == '__main__':
+    enaml_demo()

--- a/examples/stdlib/range_demo_view.enaml
+++ b/examples/stdlib/range_demo_view.enaml
@@ -1,0 +1,172 @@
+#------------------------------------------------------------------------------
+#  Copyright (c) 2011, Enthought, Inc.
+#  All rights reserved.
+#------------------------------------------------------------------------------
+
+#
+# Defines a UI view for the RangeDemo class in range_demo.py
+#
+
+from enaml.stdlib.fields import IntField, LongField, FloatField, HexField
+
+
+BoldLabel(Label):
+    font = 'times 14 bold'
+
+defn RangeDemoView(demo):
+    Window:
+        title = "Range Demo"
+
+        constraints = [
+            vbox(
+                hbox(col1title, col2title, col3title, col4title),
+                hbox(i_name, i_type, i_range, i),
+                hbox(digit_name, digit_type, digit_range, digit),
+                hbox(h_name, h_type, h_range, h),
+                hbox(bigint_name, bigint_type, bigint_range, bigint),
+                hbox(z_name, z_type, z_range, z),
+                hbox(b_min_name, b_min_type, b_min_range, b_min),
+                hbox(b_max_name, b_max_type, b_max_range, b_max),
+                hbox(b_name, b_type, b_range, b),
+            ) | 'strong',
+            align('left', col1title, i_name, digit_name, h_name, bigint_name,
+                            z_name, b_min_name, b_max_name, b_name),
+            align('left', col2title, i_type, digit_type, h_type, bigint_type,
+                            z_type, b_min_type, b_max_type, b_type),
+            align('left', col3title, i_range, digit_range, h_range, bigint_range,
+                            z_range, b_min_range, b_max_range, b_range),
+            align('left', col4title, i, digit, h, bigint, z, b_min, b_max, b),
+        ]
+
+        BoldLabel:
+            id: col1title
+            text = 'Name       '
+        BoldLabel:
+            id: col2title
+            text = 'Type'
+        BoldLabel:
+            id: col3title
+            text = 'Range'
+        BoldLabel:
+            id: col4title
+            text = 'Value'
+
+        Label:
+            id: i_name
+            text = 'i'
+        Label:
+            id: i_type
+            text = 'int'
+        Label:
+            id: i_range
+            text = 'i >= 0'
+        IntField:
+            id: i
+            low = 0
+            value := demo.i
+
+        Label:
+            id: digit_name
+            text = 'digit'
+        Label:
+            id: digit_type
+            text = 'int'
+        Label:
+            id: digit_range
+            text = '0 <= digit <= 9'
+        IntField:
+            id: digit
+            low = 0
+            high = 9
+            value := demo.digit
+
+        Label:
+            id: h_name
+            text = 'h'
+        Label:
+            id: h_type
+            text = 'int, in hex'
+        Label:
+            id: h_range
+            text = '0x0 <= h <= 0xFF'
+        HexField:
+            id: h
+            low = 0
+            high = 255
+            value := demo.h
+
+        Label:
+            id: bigint_name
+            text = 'bigint'
+        Label:
+            id: bigint_type
+            text = 'long'
+        Label:
+            id: bigint_range
+            text = 'bigint >= 1'
+        LongField:
+            id: bigint
+            low = 1
+            value := demo.bigint
+
+        Label:
+            id: z_name
+            text = 'z'
+        Label:
+            id: z_type
+            text = 'float'
+        Label:
+            id: z_range
+            text = '0 < z <= 10'
+        FloatField:
+            id: z
+            low = 0.0
+            high = 10.0
+            allow_low = False
+            value := demo.z
+
+        Label:
+            id: b_min_name
+            text = 'b_min'
+        Label:
+            id: b_min_type
+            text = 'float'
+        Label:
+            id: b_min_range
+            text = 'b_min < 0'
+        FloatField:
+            id: b_min
+            high = 0.0
+            allow_high = False
+            value := demo.b_min
+
+        Label:
+            id: b_max_name
+            text = 'b_max'
+        Label:
+            id: b_max_type
+            text = 'float'
+        Label:
+            id: b_max_range
+            text = 'b_max >= 0'
+        FloatField:
+            id: b_max
+            low = 0.0
+            value := demo.b_max
+
+        Label:
+            id: b_name
+            text = 'b'
+        Label:
+            id: b_type
+            text = 'float'
+        Label:
+            id: b_range
+            text = 'b_min <= b <= b_max'
+        FloatField:
+            id: b
+            low << b_min.value
+            high << b_max.value
+            value := demo.b
+
+


### PR DESCRIPTION
Extend IntField, LongField, HexField, OctalField and FloatField with attributes that allow the valid values to be restricted to a range.

Run enaml/examples/stdlib/range_demo.py for a demo.
