### PR TITLE
BUG: Replace missed layout_children with constraints_children.

### DIFF
--- a/enaml/stdlib/radio_group.enaml
+++ b/enaml/stdlib/radio_group.enaml
@@ -125,7 +125,7 @@ enamldef RadioGroup(Container):
     # Synchronize the buttons when the selected index is changed
     selected_index ::
         idx = selected_index
-        buttons = layout_children
+        buttons = constraints_children
         if idx == -1:
             for button in buttons:
                 button.checked = False


### PR DESCRIPTION
Replace a missed out layout_children in 88b4b273a6 with
constraints_children.
