### PR TITLE
don't apply a new layout strength to the vbox contraint in form, or nest...

### DIFF
--- a/enaml/components/form.py
+++ b/enaml/components/form.py
@@ -78,7 +78,7 @@ class Form(Container):
         vbox_args = [hbox(label, widget) for label, widget in labels_widgets]
         if odd_child is not None:
             vbox_args.append(odd_child)
-        constraints.append(vbox(*vbox_args) | layout_strength)
+        constraints.append(vbox(*vbox_args))
 
         for label, widget in labels_widgets:
             # FIXME: baselines would be much better.


### PR DESCRIPTION
...ed containers won't layout properly.

This fixes a problem with the Form layout where one of the widgets is a container with its own vbox/hbox constraints would not layout properly. The reason is that apply a layout strength to a deferred constraints object assigns that strength to _all_ of the sub-constraints, which destroys the relationships on the child components.
