### PR TITLE
BUG: Do not clear invisible items for the midline alignment

### DIFF
--- a/examples/employee/employee_view.enaml
+++ b/examples/employee/employee_view.enaml
@@ -75,7 +75,7 @@ enamldef EmployeeView(MainWindow):
             vertical(top, top_box, bottom_box.when(bottom_box.visible), bottom),
             horizontal(left, spacer.flex(), top_box, spacer.flex(), right),
             horizontal(left, spacer.flex(), bottom_box, spacer.flex(), right),
-            align('midline', top_form, bottom_form)
+            align('midline', top_form, bottom_form, clear_invisible=False)
         ]
         GroupBox:
             id: top_box


### PR DESCRIPTION
in the Employee example. Otherwise, we will only have one item being aligned initially, which is an error.
