### PR TITLE
Work around for PySide's QImage behavior

### DIFF
--- a/enaml/backends/qt/noncomponents/qt_image.py
+++ b/enaml/backends/qt/noncomponents/qt_image.py
@@ -13,7 +13,7 @@ class QtImage(AbstractTkImage):
     """ A Qt4 implementation of AbstractTkImage.
     
     """
-    def __init__(self, qimage=None, data=None):
+    def __init__(self, qimage=None):
         """ Initialize a QtImage.
 
         Parameters
@@ -22,18 +22,10 @@ class QtImage(AbstractTkImage):
             A QImage instance which holds the data. If None is passed, 
             then an empty QImage will be created.
 
-        data : a bytearray instance or None, optional
-            A bytearray instance which holds the image data. This is needed
-            because the QImage instance does not hold a strong reference to
-            its image buffer when constructed from a buffer (as opposed to a
-            file, say). If None is passed, then the QImage is assumed to have
-            been constructed from a file.
-
         """
         if qimage is None:
             qimage = QImage()
         self._qimage = qimage
-        self._data = data
     
     #--------------------------------------------------------------------------
     # Abstract API Implementation
@@ -69,8 +61,11 @@ class QtImage(AbstractTkImage):
 
         w, h = size
         img_data = str(qt_array)
-        return cls(qimage=QImage(img_data, w, h, QImage.Format_ARGB32),
-                   data=img_data)
+        qimg = QImage(img_data, w, h, QImage.Format_ARGB32)
+        # Add a strong reference to the data so it doesn't get pulled out from
+        # under the QImage object.
+        qimg._data_keepalive_ptr = img_data
+        return cls(qimg)
 
     @classmethod
     def from_file(cls, path, format=''):


### PR DESCRIPTION
When using Image.from_data(), the data can disappear out from under the QImage unless a reference is held. See the PySide docs:
http://www.pyside.org/docs/pyside/PySide/QtGui/QImage.html#PySide.QtGui.QImage
