### PR TITLE
Add better traceback message to ExpressionInitializationError.

### DIFF
--- a/enaml/core/trait_types.py
+++ b/enaml/core/trait_types.py
@@ -227,10 +227,12 @@ class ExpressionTrait(TraitType):
                 if isinstance(e, ExpressionInitializationError):
                     raise
                 msg = ('Error initializing expression (%r line %s). '
-                       'Orignal exception was: %s.')
+                       'Orignal exception was:\n%s')
+                import traceback
+                tb = traceback.format_exc()
                 filename = expr.code.co_filename
                 lineno = expr.code.co_firstlineno
-                args = (filename, lineno, e)
+                args = (filename, lineno, tb)
                 raise ExpressionInitializationError(msg % args)
         return res
 


### PR DESCRIPTION
After spending half an hour trying to work out where the *#&$^! an error was occurring in an Enaml file, I fixed up the code so that when you get an ExpressionInitializationError it includes the full traceback of the original error.
