### PR TITLE
Remove unused import.  (fixes inability to 'make html' in docs)

### DIFF
--- a/enamldoc/sphinx_ext.py
+++ b/enamldoc/sphinx_ext.py
@@ -23,8 +23,6 @@ from sphinx.ext.autodoc import ModuleDocumenter
 
 from enaml_domain import EnamlDomain
 
-from enthought.debug.api import called_from
-
 from enaml.core.import_hooks import EnamlImporter
 EnamlImporter.install()
 


### PR DESCRIPTION
If `called_from` is needed again,
import it from `etsdevtools.debug.api`
and not `enthought.debug.api`.
