### PR TITLE
BUG: Set `initialized` to False when destroying a component.

### DIFF
--- a/enaml/core/base_component.py
+++ b/enaml/core/base_component.py
@@ -297,6 +297,7 @@ class BaseComponent(HasStrictTraits):
         for child in self._subcomponents:
             child.destroy()
         del self._subcomponents[:]
+        self.initialized = False
         self._expressions.clear()
 
     #--------------------------------------------------------------------------


### PR DESCRIPTION
Sometimes when using a `::` operator, the notification will be fired after the component has been destroyed and the expressions cleared out.

https://github.com/enthought/enaml/blob/master/enaml/core/base_component.py#L529

Since this is guarded by checking `initialized`, I think it makes sense to "de-initialize" the component on destruction.
