### PR TITLE
FIX: Hyperlink navigation support for Html widget.

### DIFF
--- a/enaml/backends/qt/qt_html.py
+++ b/enaml/backends/qt/qt_html.py
@@ -19,7 +19,7 @@ class QtHtml(QtControl, AbstractTkHtml):
         """ Creates the underlying widget to display HTML.
 
         """
-        self.widget = QtGui.QTextEdit(parent)
+        self.widget = QtGui.QTextBrowser(parent)
 
     def initialize(self):
         """ Initializes the attributes of the control.


### PR DESCRIPTION
Using QTextBrowser instead of QTextEdit for qt backend of Html widget.
