### PR TITLE
BUG: Fix uses of logging to use locally-named loggers.

### DIFF
--- a/enaml/__init__.py
+++ b/enaml/__init__.py
@@ -3,6 +3,28 @@
 #  All rights reserved.
 #------------------------------------------------------------------------------
 
+#------------------------------------------------------------------------------
+# Logging Setup
+#------------------------------------------------------------------------------
+# Add a NullHandler to make sure that all enaml loggers don't complain when they
+# get used.
+import logging
+
+class NullHandler(logging.Handler):
+    def handle(self, record):
+        pass
+
+    def emit(self, record):
+        pass
+
+    def createLock(self):
+        self.lock = None
+
+logger = logging.getLogger(__name__)
+logger.addHandler(NullHandler())
+
+del logging, logger, NullHandler
+
 
 #------------------------------------------------------------------------------
 # Import Helper

--- a/enaml/application.py
+++ b/enaml/application.py
@@ -10,6 +10,9 @@ from threading import Lock
 import uuid
 
 from enaml.core.object import Object
+
+
+logger = logging.getLogger(__name__)
     
 
 class ScheduledTask(object):
@@ -321,7 +324,7 @@ class Application(object):
             if name in named_factories:
                 msg = 'Multiple session factories named `%s`; ' % name
                 msg += 'replacing previous value.'
-                logging.warn(msg)
+                logger.warn(msg)
                 old_factory = named_factories.pop(name)
                 all_factories.remove(old_factory)
             all_factories.append(factory)

--- a/enaml/core/object.py
+++ b/enaml/core/object.py
@@ -18,6 +18,9 @@ from enaml.utils import LoopbackGuard, id_generator
 from .trait_types import EnamlEvent
 
 
+logger = logging.getLogger(__name__)
+
+
 class ActionPipeInterface(object):
     """ An abstract base class defining an action pipe interface.
 
@@ -615,9 +618,8 @@ class Object(HasStrictTraits):
         if handler is not None:
             handler(content)
         else:
-            # XXX make this logging more configurable
             msg = "Unhandled action '%s' for Object %s:%s"
-            logging.warn(msg % (action, self.class_name, self.object_id))
+            logger.warn(msg % (action, self.class_name, self.object_id))
 
     def inherit_pipe(self):
         """ Inherit the action pipe from the ancestors of this object.

--- a/enaml/qt/qt_builder.py
+++ b/enaml/qt/qt_builder.py
@@ -7,6 +7,9 @@ import logging
 from .qt_factories import QT_FACTORIES
 
 
+logger = logging.getLogger(__name__)
+
+
 class QtBuilder(object):
     """ An object which manages building a QtObject tree from an Enaml
     snapshot dict.
@@ -55,7 +58,7 @@ class QtBuilder(object):
             msg =  'Unhandled object type: %s:%s'
             item_class = tree['class']
             item_bases = tree['bases']
-            logging.error(msg % (item_class, item_bases))
+            logger.error(msg % (item_class, item_bases))
             return
         obj = obj_cls.construct(tree, parent, pipe, self)
         for child in tree['children']:

--- a/enaml/qt/qt_object.py
+++ b/enaml/qt/qt_object.py
@@ -11,6 +11,9 @@ from .qt.QtCore import QObject
 from .q_deferred_caller import QDeferredCaller
 
 
+logger = logging.getLogger(__name__)
+
+
 def deferred_updates(func):
     """ A method decorator which will defer widget updates.
 
@@ -535,7 +538,7 @@ class QtObject(object):
             handler(content)
         else:
             msg = "Unhandled action '%s' for QtObject %s:%s"
-            logging.warn(msg % (action, type(self).__name__, self._object_id))
+            logger.warn(msg % (action, type(self).__name__, self._object_id))
 
     def send_action(self, action, content):
         """ Send an action on the action pipe for this object.

--- a/enaml/utils.py
+++ b/enaml/utils.py
@@ -285,9 +285,10 @@ def log_exceptions(func):
         try:
             res = func(*args, **kwargs)
         except Exception:
-            tb = traceback.format_exc()
-            message = 'Exception occured in `%s`:\n%s' % (func.__name__, tb)
-            logging.error(message)
+            # Get the logger for the wrapped function.
+            logger = logging.getLogger(func.__module__)
+            message = 'Exception occured in `%s`:' % func.__name__
+            logger.exception(message)
             res = None
         return res
     return closure

--- a/enaml/wx/wx_builder.py
+++ b/enaml/wx/wx_builder.py
@@ -7,6 +7,9 @@ import logging
 from .wx_factories import WX_FACTORIES
 
 
+logger = logging.getLogger(__name__)
+
+
 class WxBuilder(object):
     """ An object which manages building a WxObject tree from an Enaml
     snapshot dict.
@@ -55,7 +58,7 @@ class WxBuilder(object):
             msg =  'Unhandled object type: %s:%s'
             item_class = tree['class']
             item_bases = tree['bases']
-            logging.error(msg % (item_class, item_bases))
+            logger.error(msg % (item_class, item_bases))
             return
         obj = obj_cls.construct(tree, parent, pipe, self)
         for child in tree['children']:

--- a/enaml/wx/wx_object.py
+++ b/enaml/wx/wx_object.py
@@ -12,6 +12,9 @@ from enaml.utils import LoopbackGuard
 from .wx_deferred_caller import wxDeferredCaller
 
 
+logger = logging.getLogger(__name__)
+
+
 def deferred_updates(func):
     """ A method decorator which will defer widget updates.
 
@@ -537,7 +540,7 @@ class WxObject(object):
             handler(content)
         else:
             msg = "Unhandled action '%s' for WxObject %s:%s"
-            logging.warn(msg % (action, type(self).__name__, self._object_id))
+            logger.warn(msg % (action, type(self).__name__, self._object_id))
 
     def send_action(self, action, content):
         """ Send an action on the action pipe for this object.


### PR DESCRIPTION
This PR fixes the use of logging to follow accepted best practice for libraries. Namely, each module will have its own logger configured with its `__name__`. This establishes a hierarchy of loggers starting with `'enaml'`. Configuring handlers for `'enaml'` will handle all sub-loggers in the enaml package. A `NullHandler` is attached to the `'enaml'` root logger to silence the (acknowledged) ill-conceived misfeature of printing out when a logging message is sent to a logger without a handler. This is considered best practice for libraries. Logging can be configured in any of the normal means documented in the standard library documentation.
