### PR TITLE
Sync enaml with chaco

### DIFF
--- a/enaml/runner.py
+++ b/enaml/runner.py
@@ -30,7 +30,7 @@ def prepare_toolkit(toolkit_option):
     Parameters
     ----------
     toolkit_option : str
-        The toolkit option provided to the enaml-run script
+        The toolkit option provided to the enaml-run script.
 
     Returns
     -------
@@ -46,14 +46,13 @@ def prepare_toolkit(toolkit_option):
             enaml_toolkit = 'wx' if toolkit_option == 'wx' else 'qt'
             if ets_toolkit != enaml_toolkit:
                 msg = (
-                    'The --toolkit option is different from the '
-                    'ETS_TOOLKIT environment variable which can '
-                    'cause issues if enable or chaco components '
-                    'are used.'
+                    'The --toolkit option is different from the ETS_TOOLKIT '
+                    'environment variable, which can cause incompatibility '
+                    'issues when using enable or chaco components.'
                 )
                 warnings.warn(msg)
     else:
-        if toolkit_option = 'wx':
+        if toolkit_option == 'wx':
             enaml_toolkit = 'wx'
             os.environ['ETS_TOOLKIT'] = 'wx'
         else:
@@ -97,7 +96,7 @@ def main():
     module.__file__ = enaml_file
     ns = module.__dict__
 
-    # Put the directory of the Enaml file first in the path so relative 
+    # Put the directory of the Enaml file first in the path so relative
     # imports can work.
     sys.path.insert(0, os.path.abspath(os.path.dirname(enaml_file)))
     # Bung in the command line arguments.


### PR DESCRIPTION
This pr re-introduces the logic to overcome issue #168

With this `enaml-run` will behave as follows.
- If `ETS_TOOLKIT`  is set and the `--toolkit` option is not `enaml-run` will respect `ETS_TOOLKIT` value and use  the related backed.
- if `ETS_TOOLKIT` is set  and the `--toolkit` option is set to an incompatible backend then a warning is
  raised, but `enaml-run` will still honor the `--toolkit` option.
- if `ETS_TOOLKIT` is not set then `enaml-run` with temporarily set the compatible backend in os.environ so that chaco and enaml components are in sync.
