### PR TITLE
BUG: when aligning one or zero items, silently return no constraints.

### DIFF
--- a/enaml/layout/layout_helpers.py
+++ b/enaml/layout/layout_helpers.py
@@ -310,6 +310,10 @@ class AlignmentHelper(DeferredConstraints):
 
         """
         items = [item for item in self.items if item is not None]
+        # If there are less than two items, no alignment needs to
+        # happen, so return no constraints.
+        if len(items) < 2:
+            return []
         factories = AlignmentConstraintFactory.from_items(
             items, self.anchor, self.spacing,
         )


### PR DESCRIPTION
This happens frequently when one uses constructions like `align('height', *constraints_children)`
