### PR TITLE
BUG: Fixes SyntaxError when enaml file has DOS line endings in Linux

### DIFF
--- a/enaml/core/import_hooks.py
+++ b/enaml/core/import_hooks.py
@@ -342,7 +342,7 @@ class EnamlImporter(AbstractEnamlImporter):
                 return (code, file_info.src_path)
 
         # Otherwise, compile from source and attempt to cache
-        with open(file_info.src_path) as src_file:
+        with open(file_info.src_path, 'rU') as src_file:
             src = src_file.read()
         ast = parse(src)
         code = EnamlCompiler.compile(ast, file_info.src_path)

--- a/enaml/runner.py
+++ b/enaml/runner.py
@@ -83,7 +83,7 @@ def main():
         enaml_file = args[0]
         script_argv = args[1:]
 
-    with open(enaml_file) as f:
+    with open(enaml_file, 'rU') as f:
         enaml_code = f.read()
 
     # Parse and compile the Enaml source into a code object


### PR DESCRIPTION
Fixes #249 by opening the enaml file with universal newline support.
