### PR TITLE
add `current_index` attribute to Notebook

### DIFF
--- a/enaml/qt/qt_notebook.py
+++ b/enaml/qt/qt_notebook.py
@@ -281,6 +281,9 @@ class QtNotebook(QtConstraintsWidget):
         self.set_tab_position(tree['tab_position'])
         self.set_tabs_closable(tree['tabs_closable'])
         self.set_tabs_movable(tree['tabs_movable'])
+        self.set_current_index(tree['current_index'])
+        widget = self.widget()
+        widget.currentChanged.connect(self.on_current_index_changed)
 
     def init_layout(self):
         """ Handle the layout initialization for the notebook.
@@ -321,6 +324,14 @@ class QtNotebook(QtConstraintsWidget):
         """
         self.size_hint_updated()
 
+    def on_current_index_changed(self, index):
+        """ Handle the `currentChanged` signal from the QNotebook.
+
+        """
+        if 'current_index' not in self.loopback_guard:
+            content = {'current_index': index}
+            self.send_action('current_index_changed', content)
+
     #--------------------------------------------------------------------------
     # Message Handlers
     #--------------------------------------------------------------------------
@@ -347,6 +358,12 @@ class QtNotebook(QtConstraintsWidget):
 
         """
         self.set_tabs_movable(content['tabs_movable'])
+
+    def on_action_set_current_index(self, content):
+        """ Handle the 'set_current_index action from the Enaml widget.
+
+        """
+        self.set_current_index(content['current_index'])
 
     #--------------------------------------------------------------------------
     # Widget Update Methods
@@ -375,3 +392,9 @@ class QtNotebook(QtConstraintsWidget):
         """
         self.widget().setMovable(movable)
 
+    def set_current_index(self, index):
+        """ Set whether or not the tabs are movable.
+
+        """
+        with self.loopback_guard('current_index'):
+            self.widget().setCurrentIndex(index)

--- a/enaml/widgets/notebook.py
+++ b/enaml/widgets/notebook.py
@@ -2,7 +2,7 @@
 #  Copyright (c) 2012, Enthought, Inc.
 #  All rights reserved.
 #------------------------------------------------------------------------------
-from traits.api import Enum, Bool, Property, cached_property
+from traits.api import Enum, Bool, Property, cached_property, Int
 
 from .constraints_widget import ConstraintsWidget
 from .page import Page
@@ -10,7 +10,7 @@ from .page import Page
 
 class Notebook(ConstraintsWidget):
     """ A component which displays its children as tabbed pages.
-    
+
     """
     #: The style of tabs to use in the notebook. Preferences style
     #: tabs are appropriate for configuration dialogs and the like.
@@ -26,6 +26,9 @@ class Notebook(ConstraintsWidget):
 
     #: Whether or not the tabs in the notebook should be movable.
     tabs_movable = Bool(True)
+
+    #: The index of the currently selected Page
+    current_index = Int()
 
     #: A read only property which returns the notebook's Pages.
     pages = Property(depends_on='children')
@@ -50,6 +53,7 @@ class Notebook(ConstraintsWidget):
         snap['tab_position'] = self.tab_position
         snap['tabs_closable'] = self.tabs_closable
         snap['tabs_movable'] = self.tabs_movable
+        snap['current_index'] = self.current_index
         return snap
 
     def bind(self):
@@ -59,8 +63,20 @@ class Notebook(ConstraintsWidget):
         super(Notebook, self).bind()
         attrs = (
             'tab_style', 'tab_position', 'tabs_closable', 'tabs_movable',
+            'current_index'
         )
         self.publish_attributes(*attrs)
+
+    #--------------------------------------------------------------------------
+    # Message Handlers
+    #--------------------------------------------------------------------------
+    def on_action_current_index_changed(self, content):
+        """ Handle the 'current_index_changed' action from the UI widget.
+
+        The content will contain the current index.
+
+        """
+        self.current_index = content['current_index']
 
     #--------------------------------------------------------------------------
     # Private API
@@ -79,4 +95,3 @@ class Notebook(ConstraintsWidget):
         isinst = isinstance
         pages = (child for child in self.children if isinst(child, Page))
         return tuple(pages)
-


### PR DESCRIPTION
This PR adds a current index attribute to the Notebook. This is useful if you need to know which page is selected at any given time.

I have only implemented this for Qt. I do not know wx or how long it might take to implement it there.
