### PR TITLE
Add a 'text_edited' submit trigger to 'Field' widget.

### DIFF
--- a/enaml/qt/qt_field.py
+++ b/enaml/qt/qt_field.py
@@ -131,16 +131,10 @@ class QtField(QtControl):
             self._validate_and_submit()
 
     def on_text_edited(self):
-        # Temporary kludge until styles are fully implemented
-        widget = self.widget()
-        if self._validator(widget.text()):
-            if self._is_error_state:
-                self._clear_error_style()
-                widget.setToolTip('')
-        else:
-            if not self._is_error_state:
-                self._set_error_style()
-                widget.setToolTip(self._validator_message)
+        """ The signal handler for 'textEdited' signal.
+        """
+        if 'text_edited' in self._submit_triggers:
+            self._validate_and_submit()
 
     #--------------------------------------------------------------------------
     # Message Handlers

--- a/enaml/widgets/field.py
+++ b/enaml/widgets/field.py
@@ -27,9 +27,11 @@ class Field(Control):
 
     #: The list of actions which should cause the client to submit its
     #: text to the server for validation and update. The currently
-    #: supported values are 'lost_focus' and 'return_pressed'.
+    #: supported values are 'lost_focus', 'return_pressed' and 
+    #: 'text_edited' .
     submit_triggers = List(
-        Enum('lost_focus', 'return_pressed'), ['lost_focus', 'return_pressed']
+        Enum('lost_focus', 'return_pressed', 'text_edited'), 
+            ['lost_focus', 'return_pressed', 'text_edited']
     )
 
     #: The grayed-out text to display if the field is empty and the

--- a/enaml/wx/wx_field.py
+++ b/enaml/wx/wx_field.py
@@ -250,17 +250,12 @@ class WxField(WxControl):
             self._validate_and_submit()
 
     def on_text_edited(self, event):
-        # Temporary kludge until styles are fully implemented
+        """ The event handler for EVT_TEXT event.
+
+        """
         event.Skip()
-        widget = self.widget()
-        if self._validator(widget.GetValue()):
-            if self._is_error_state:
-                self._clear_error_style()
-                widget.SetToolTip(wx.ToolTip(''))
-        else:
-            if not self._is_error_state:
-                self._set_error_style()
-                widget.SetToolTip(wx.ToolTip(self._validator_message))
+        if 'text_edited' in self._submit_triggers:
+            self._validate_and_submit()
 
     #--------------------------------------------------------------------------
     # Message Handling


### PR DESCRIPTION
This trigger is useful if one wants to provide dynamic visual feedback
to the user as he types. For example, immediate color change in email
field as soon as the email becomes invalid.
