### PR TITLE
FIX: Remove 'text_edited' from the default submit_triggers of 'Field' widget.

### DIFF
--- a/enaml/widgets/field.py
+++ b/enaml/widgets/field.py
@@ -31,7 +31,7 @@ class Field(Control):
     #: 'text_edited' .
     submit_triggers = List(
         Enum('lost_focus', 'return_pressed', 'text_edited'), 
-            ['lost_focus', 'return_pressed', 'text_edited']
+            ['lost_focus', 'return_pressed']
     )
 
     #: The grayed-out text to display if the field is empty and the


### PR DESCRIPTION
Keeping it in the default list modifies existing behavior and is
likely to break things. 
(see: https://github.com/enthought/enaml/commit/ce054bd9c9ebdc2d25d86c2f7cd19a6801caa9b7#commitcomment-3222365)
